### PR TITLE
fix scratchcpp#317: the number of periods in a loop should be rounded

### DIFF
--- a/src/engine/virtualmachine_p.cpp
+++ b/src/engine/virtualmachine_p.cpp
@@ -260,7 +260,7 @@ do_forever_loop:
     DISPATCH();
 
 do_repeat_loop:
-    loopCount = READ_LAST_REG()->toLong();
+    loopCount = std::round(READ_LAST_REG()->toDouble());
     FREE_REGS(1);
     if (loopCount <= 0) {
         loopEnd = pos;

--- a/test/virtual_machine/virtual_machine_test.cpp
+++ b/test/virtual_machine/virtual_machine_test.cpp
@@ -254,15 +254,32 @@ TEST(VirtualMachineTest, OP_FOREVER_LOOP)
 TEST(VirtualMachineTest, OP_REPEAT_LOOP)
 {
     static unsigned int bytecode[] = { OP_START, OP_CONST, 0, OP_REPEAT_LOOP, OP_CONST, 1, OP_PRINT, OP_LOOP_END, OP_HALT };
-    static Value constValues[] = { 3, "test" };
+    static Value constValues1[] = { 3, "test" };
+    static Value constValues2[] = { 4.5, "test" };
+    static Value constValues3[] = { 4.2, "test" };
 
     EngineMock engineMock;
     VirtualMachine vm(nullptr, &engineMock, nullptr);
     vm.setBytecode(bytecode);
-    vm.setConstValues(constValues);
+    vm.setConstValues(constValues1);
     testing::internal::CaptureStdout();
     vm.run();
     ASSERT_EQ(testing::internal::GetCapturedStdout(), "test\ntest\ntest\n");
+    ASSERT_EQ(vm.registerCount(), 0);
+
+    // For #317
+    vm.setConstValues(constValues2);
+    testing::internal::CaptureStdout();
+    vm.reset();
+    vm.run();
+    ASSERT_EQ(testing::internal::GetCapturedStdout(), "test\ntest\ntest\ntest\ntest\n");
+    ASSERT_EQ(vm.registerCount(), 0);
+
+    vm.setConstValues(constValues3);
+    testing::internal::CaptureStdout();
+    vm.reset();
+    vm.run();
+    ASSERT_EQ(testing::internal::GetCapturedStdout(), "test\ntest\ntest\ntest\n");
     ASSERT_EQ(vm.registerCount(), 0);
 }
 


### PR DESCRIPTION
Resolves: #317